### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,4 +64,5 @@ gem 'active_hash'
 gem 'mini_magick'
 gem 'image_processing', '~>1.2'
 gem 'payjp'
-gem "aws-sdk-s3", require: false
+gem 'aws-sdk-s3', require: false
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
+    rails-i18n (7.0.5)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (6.0.5.1)
       actionpack (= 6.0.5.1)
       activesupport (= 6.0.5.1)
@@ -335,6 +338,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rspec-rails (~> 4.0.0)
   rubocop
   sass-rails (~> 5)

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -6,13 +6,13 @@ class OrderAddress
 
   with_options presence: true do
     validates :post_code,    format: { with: /\A[0-9]{3}-[0-9]{4}\z/, allow_blank: true}
-    validates :prefecture_id, numericality: { other_than: 1, message: "isn't selected" }
+    validates :prefecture_id, numericality: { other_than: 1, message: "を選択してください" }
     validates :city
     validates :house_number
     validates :phone_number, format: { with: /\A\d{10,11}\z/ }
-    validates :token
-    validates :user_id
-    validates :product_id
+    validates :token       ,presence:{ message: "を全て入力してください" }
+    validates :user_id     ,presence:{ message: "が紐づいていません" }
+    validates :product_id  ,presence:{ message: "が紐づいていません" }
   end
 
   def save

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -14,11 +14,12 @@ class Product < ApplicationRecord
   validates :image,              presence: true
   validates :product_name,       presence: true, length: { maximum: 40 }
   validates :description,        presence: true, length: { maximum: 1000 }
-  validates :price,              presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 300,
-                                                                 less_than_or_equal_to: 9_999_999 }
-  validates :category_id,        presence: true, numericality: { other_than: 1, message: "can't be blank" }
-  validates :condition_id,       presence: true, numericality: { other_than: 1, message: "can't be blank" }
-  validates :delivery_charge_id, presence: true, numericality: { other_than: 1, message: "can't be blank" }
-  validates :prefecture_id,      presence: true, numericality: { other_than: 1, message: "can't be blank" }
-  validates :delivery_days_id,   presence: true, numericality: { other_than: 1, message: "can't be blank" }
+  validates :price,              presence: true, numericality: { only_integer: true, message: "は半角数字のみで入力してください" }
+  validates :price,              presence: true, numericality: {greater_than_or_equal_to: 300, message: "は300円以上にしてください"}
+  validates :price,              presence: true, numericality: {less_than_or_equal_to: 9_999_999, message: "は9,999,999円以下にしてください", allow_blank: true }
+  validates :category_id,        presence: true, numericality: { other_than: 1, message: "を選択してください", allow_blank: true }
+  validates :condition_id,       presence: true, numericality: { other_than: 1, message: "を選択してください", allow_blank: true }
+  validates :delivery_charge_id, presence: true, numericality: { other_than: 1, message: "を選択してください", allow_blank: true }
+  validates :prefecture_id,      presence: true, numericality: { other_than: 1, message: "を選択してください", allow_blank: true }
+  validates :delivery_days_id,   presence: true, numericality: { other_than: 1, message: "を選択してください", allow_blank: true }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,10 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :nickname, presence: true
-  validates :password,                            format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }
-  validates :family_name,        presence: true,  format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/ }
-  validates :personal_name,      presence: true,  format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/ }
-  validates :family_name_kana,   presence: true,  format: { with: /\A[ァ-ヶー－]+\z/ }
-  validates :personal_name_kana, presence: true,  format: { with: /\A[ァ-ヶー－]+\z/ }
+  validates :password,                            format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, allow_blank: true }
+  validates :family_name,        presence: true,  format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/, allow_blank: true }
+  validates :personal_name,      presence: true,  format: { with: /\A[ぁ-んァ-ン一-龥々ー]+\z/, allow_blank: true }
+  validates :family_name_kana,   presence: true,  format: { with: /\A[ァ-ヶー－]+\z/, allow_blank: true }
+  validates :personal_name_kana, presence: true,  format: { with: /\A[ァ-ヶー－]+\z/, allow_blank: true }
   validates :birthday,           presence: true
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Furima37925
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/device.ja.yml
+++ b/config/locales/device.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,37 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: 確認用パスワード
+        family_name: 名字
+        personal_name: 名前
+        family_name_kana: 名字(カナ)
+        personal_name_kana: 名前(カナ)
+        birthday: 生年月日
+      product:
+        image: 商品画像
+        product_name: 商品名
+        description: 商品の説明
+        price: 販売価格
+        category_id: カテゴリー
+        condition_id: 商品の状態
+        delivery_charge_id: 配送料の負担
+        prefecture_id: 発送元の地域
+        delivery_days_id: 発送までの日数
+
+  activemodel:
+    attributes:
+      order_address:
+        post_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        house_number: 番地
+        building: 建物名
+        phone_number: 電話番号
+        token: カード情報
+        user_id: ユーザー情報
+        product_id: 商品情報
+

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -24,85 +24,85 @@ RSpec.describe OrderAddress, type: :model do
         @order_address.post_code = ''
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Post code can't be blank")
+        .to include("郵便番号を入力してください")
       end
       it '郵便番号にハイフンが含まれていないと購入できないこと' do
         @order_address.post_code = '1234567'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Post code is invalid")
+        .to include("郵便番号は不正な値です")
       end
       it '郵便番号が7桁未満だと購入できないこと' do
         @order_address.post_code = '123-456'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Post code is invalid")
+        .to include("郵便番号は不正な値です")
       end
       it '郵便番号が8桁以上だと購入できないこと' do
         @order_address.post_code = '1234-5678'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Post code is invalid")
+        .to include("郵便番号は不正な値です")
       end
       it '都道府県が空だと購入できないこと' do
         @order_address.prefecture_id = 1
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Prefecture isn't selected")
+        .to include("都道府県を選択してください")
       end
       it '市区町村が空だと購入できないこと' do
         @order_address.city = ''
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("City can't be blank")
+        .to include("市区町村を入力してください")
       end
       it '番地が空だと購入できないこと' do
         @order_address.house_number = ''
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("House number can't be blank")
+        .to include("番地を入力してください")
       end
       it '電話番号が空だと購入できないこと' do
         @order_address.phone_number = ''
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Phone number can't be blank")
+        .to include("電話番号を入力してください")
       end
       it '電話番号にハイフンが含まれていると購入できないこと' do
         @order_address.phone_number = '123-456-789'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Phone number is invalid")
+        .to include("電話番号は不正な値です")
       end
       it '電話番号が12桁以上の半角数値だと購入できないこと' do
         @order_address.phone_number = '123456789012'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Phone number is invalid")
+        .to include("電話番号は不正な値です")
       end
       it '電話番号が9桁以下の半角数値だと購入できないこと' do
         @order_address.phone_number = '123456789'
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Phone number is invalid")
+        .to include("電話番号は不正な値です")
       end
       it "tokenが空では登録できないこと" do
         @order_address.token = nil
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Token can't be blank")
+        .to include("カード情報を全て入力してください")
       end
       it 'user_idが空では購入できないこと' do
         @order_address.user_id = nil
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("User can't be blank")
+        .to include("ユーザー情報が紐づいていません")
       end
       it 'product_idが空では購入できないこと' do
         @order_address.product_id = nil
         @order_address.valid?
         expect(@order_address.errors.full_messages)
-        .to include("Product can't be blank")
+        .to include("商品情報が紐づいていません")
       end
     end
   end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -18,72 +18,72 @@ RSpec.describe Product, type: :model do
       it '商品画像が1枚もついていないと出品できないこと' do
         @product.image = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include("Image can't be blank")
+        expect(@product.errors.full_messages).to include("商品画像を入力してください")
       end
       it '商品名が空だと出品できないこと' do
         @product.product_name = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Product name can't be blank")
+        expect(@product.errors.full_messages).to include("商品名を入力してください")
       end
       it '商品の説明が空だと出品できないこと' do
         @product.description = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Description can't be blank")
+        expect(@product.errors.full_messages).to include("商品の説明を入力してください")
       end
       it 'カテゴリーの情報が空だと出品できないこと' do
         @product.category_id = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Category can't be blank")
+        expect(@product.errors.full_messages).to include("カテゴリーを入力してください")
       end
       it '商品の状態の情報が空だと出品できないこと' do
         @product.condition_id = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Condition can't be blank")
+        expect(@product.errors.full_messages).to include("商品の状態を入力してください")
       end
       it '配送料の負担の情報が空だと出品できないこと' do
         @product.delivery_charge_id = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Delivery charge can't be blank")
+        expect(@product.errors.full_messages).to include("配送料の負担を入力してください")
       end
       it '発送元の地域の情報が空だと出品できないこと' do
         @product.prefecture_id = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Prefecture can't be blank")
+        expect(@product.errors.full_messages).to include("発送元の地域を入力してください")
       end
       it '発送までの日数の情報が空だと出品できないこと' do
         @product.delivery_days_id = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Delivery days can't be blank")
+        expect(@product.errors.full_messages).to include("発送までの日数を入力してください")
       end
       it '価格の情報が空だと出品できないこと' do
         @product.price = ''
         @product.valid?
-        expect(@product.errors.full_messages).to include("Price can't be blank")
+        expect(@product.errors.full_messages).to include("販売価格を入力してください")
       end
       it '価格が¥300未満だと出品できないこと' do
         @product.price = 299
         @product.valid?
-        expect(@product.errors.full_messages).to include('Price must be greater than or equal to 300')
+        expect(@product.errors.full_messages).to include('販売価格は300円以上にしてください')
       end
       it '価格が¥9,999,999より大きいと出品できないこと' do
         @product.price = 10_000_000
         @product.valid?
-        expect(@product.errors.full_messages).to include('Price must be less than or equal to 9999999')
+        expect(@product.errors.full_messages).to include('販売価格は9,999,999円以下にしてください')
       end
       it '価格が半角数値以外だと出品できないこと' do
         @product.price = '３００'
         @product.valid?
-        expect(@product.errors.full_messages).to include('Price is not a number')
+        expect(@product.errors.full_messages).to include('販売価格は半角数字のみで入力してください')
       end
       it '価格にコンマが入ると出品できないこと' do
         @product.price = '1,000'
         @product.valid?
-        expect(@product.errors.full_messages).to include('Price is not a number')
+        expect(@product.errors.full_messages).to include('販売価格は半角数字のみで入力してください')
       end
       it 'ユーザー情報が紐付いていなければ出品できないこと' do
         @product.user = nil
         @product.valid?
-        expect(@product.errors.full_messages).to include("User must exist")
+        expect(@product.errors.full_messages).to include("Userを入力してください")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,115 +31,115 @@ RSpec.describe User, type: :model do
       it 'ニックネームが空では登録できないこと' do
         @user.nickname = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Nickname can't be blank")
+        expect(@user.errors.full_messages).to include("ニックネームを入力してください")
       end
       it 'メールアドレスが空では登録できないこと' do
         @user.email = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Email can't be blank")
+        expect(@user.errors.full_messages).to include("メールアドレスを入力してください")
       end
       it '重複したメールアドレスが存在する場合は登録できないこと' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include('Email has already been taken')
+        expect(another_user.errors.full_messages).to include("メールアドレスはすでに存在します")
       end
       it 'メールアドレスは、＠を含まないと登録できないこと' do
         @user.email = 'testcom'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Email is invalid')
+        expect(@user.errors.full_messages).to include("メールアドレスは不正な値です")
       end
       it 'パスワードが空では登録できないこと' do
         @user.password = ''
         @user.password_confirmation = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password can't be blank")
+        expect(@user.errors.full_messages).to include("パスワードを入力してください")
       end
       it 'パスワードが5文字以下だと登録できないこと' do
         @user.password = '123ab'
         @user.password_confirmation = '123ab'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+        expect(@user.errors.full_messages).to include("パスワードは6文字以上で入力してください")
       end
       it 'パスワードが数字のみだと登録できないこと' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'パスワードが英字のみだと登録できないこと' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'パスワードが半角以外の英数字だと登録できないこと' do
         @user.password = 'ＡＢＣ１２３'
         @user.password_confirmation = 'ＡＢＣ１２３'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Password is invalid')
+        expect(@user.errors.full_messages).to include("パスワードは不正な値です")
       end
       it 'パスワードとパスワード(確認)が異なる場合は登録できないこと' do
         @user.password = '00000a'
         @user.password_confirmation = '00000b'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+        expect(@user.errors.full_messages).to include("確認用パスワードとパスワードの入力が一致しません")
       end
       it 'お名前(全角)は、名字が空では登録できないこと' do
         @user.family_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Family name can't be blank")
+        expect(@user.errors.full_messages).to include("名字を入力してください")
       end
       it 'お名前(全角)は、名前が空では登録できないこと' do
         @user.personal_name = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Personal name can't be blank")
+        expect(@user.errors.full_messages).to include("名前を入力してください")
       end
       it 'お名前(全角)は、名字が半角では登録できないこと' do
         @user.family_name = 'ｻﾄｳ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Family name is invalid')
+        expect(@user.errors.full_messages).to include("名字は不正な値です")
       end
       it 'お名前(全角)は、名前が半角では登録できないこと' do
         @user.personal_name = 'ﾄｼｵ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Personal name is invalid')
+        expect(@user.errors.full_messages).to include("名前は不正な値です")
       end
       it 'お名前(全角)は、名字が英数字では登録できないこと' do
         @user.family_name = 'SAT0'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Family name is invalid')
+        expect(@user.errors.full_messages).to include("名字は不正な値です")
       end
       it 'お名前(全角)は、名前が英数字では登録できないこと' do
         @user.personal_name = 'TOSHI0'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Personal name is invalid')
+        expect(@user.errors.full_messages).to include("名前は不正な値です")
       end
       it 'お名前カナ(全角)は、名字が空では登録できないこと' do
         @user.family_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Family name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名字(カナ)を入力してください")
       end
       it 'お名前カナ(全角)は、名前が空では登録できないこと' do
         @user.personal_name_kana = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Personal name kana can't be blank")
+        expect(@user.errors.full_messages).to include("名前(カナ)を入力してください")
       end
       it 'お名前カナ(全角)は、名字が半角では登録できないこと' do
         @user.family_name_kana = 'ｻﾄｳ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Family name kana is invalid')
+        expect(@user.errors.full_messages).to include("名字(カナ)は不正な値です")
       end
       it 'お名前カナ(全角)は、名前が半角では登録できないこと' do
         @user.personal_name_kana = 'ﾄｼｵ'
         @user.valid?
-        expect(@user.errors.full_messages).to include('Personal name kana is invalid')
+        expect(@user.errors.full_messages).to include("名前(カナ)は不正な値です")
       end
       it '生年月日が空だと登録できない' do
         @user.birthday = ''
         @user.valid?
-        expect(@user.errors.full_messages).to include("Birthday can't be blank")
+        expect(@user.errors.full_messages).to include("生年月日を入力してください")
       end
     end
   end


### PR DESCRIPTION
# What
エラーメッセージの日本語化

# Why
入力が受け付けられなかったときに表示されるエラーメッセージが英語だったため、よりわかりやすい表示にするために日本語化を行いました。

それに伴い、テストコードの内容も書き換え、通過することを確認しました。